### PR TITLE
Add support for dynamic memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ driver:
   * amount of RAM to assign to each virtual machine.  Defaults to 536,870,912.
 * processor_count
   * number of virtual processors to assign to each virtual machine. Defaults to 2.
+* dynamic_memory
+  * if true, the amount of memory allocated to a virtual machine is adjusted by Hyper-V dynamically. Defaults to false.
+* dynamic_memory_min_bytes / dynamic_memory_max_bytes
+  * The minimum and maximum amount of memory Hyper-V will allocate to a virtual machine if dynamic_memory is enabled. Defaults to 536,870,912 and 2,147,483,648 (512MB-2GB)
 * ip_address
   * IP address for the virtual machine.  If the VM is not on a network with DHCP, this can be used to assign an IP that can be reached from the host machine.
 * vm_switch

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -37,6 +37,9 @@ module Kitchen
       default_config :parent_vhd_folder
       default_config :parent_vhd_name
       default_config :memory_startup_bytes, 536_870_912
+      default_config :dynamic_memory_min_bytes, 536_870_912
+      default_config :dynamic_memory_max_bytes, 2_147_483_648
+      default_config :dynamic_memory, false
       default_config :processor_count, 2
       default_config :ip_address
       default_config :vm_switch
@@ -80,6 +83,12 @@ module Kitchen
       def validate_vm_settings
         raise "Missing parent_vhd_folder" unless config[:parent_vhd_folder]
         raise "Missing parent_vhd_name" unless config[:parent_vhd_name]
+        if config[:dynamic_memory]
+          min = config[:dynamic_memory_min_bytes]
+          max = config[:dynamic_memory_max_bytes]
+          memory_valid = config[:memory_startup_bytes].between?(min, max)
+          raise "memory_startup_bytes must fall within dynamic memory range" unless memory_valid
+        end
         return if config[:vm_switch]
         config[:vm_switch] = (run_ps vm_default_switch_ps)['Name']
       end

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -84,10 +84,11 @@ module Kitchen
         raise "Missing parent_vhd_folder" unless config[:parent_vhd_folder]
         raise "Missing parent_vhd_name" unless config[:parent_vhd_name]
         if config[:dynamic_memory]
+          startup_bytes = config[:memory_startup_bytes]
           min = config[:dynamic_memory_min_bytes]
           max = config[:dynamic_memory_max_bytes]
-          memory_valid = config[:memory_startup_bytes].between?(min, max)
-          raise "memory_startup_bytes must fall within dynamic memory range" unless memory_valid
+          memory_valid = startup_bytes.between?(min, max)
+          raise "memory_startup_bytes (#{startup_bytes}) must fall within dynamic memory range (#{min}-#{max})" unless memory_valid
         end
         return if config[:vm_switch]
         config[:vm_switch] = (run_ps vm_default_switch_ps)['Name']

--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -99,6 +99,9 @@ module Kitchen
             VHDPath = "#{differencing_disk_path}"
             SwitchName = "#{config[:vm_switch]}"
             ProcessorCount = #{config[:processor_count]}
+            UseDynamicMemory = "#{config[:dynamic_memory]}"
+            DynamicMemoryMinBytes = #{config[:dynamic_memory_min_bytes]}
+            DynamicMemoryMaxBytes = #{config[:dynamic_memory_max_bytes]}
           }
           New-KitchenVM @NewVMParams | ConvertTo-Json
         NEWVM

--- a/support/hyperv.ps1
+++ b/support/hyperv.ps1
@@ -49,12 +49,20 @@ function New-KitchenVM
 	    $Path,
 	    $VHDPath,
 	    $SwitchName,
-	    $ProcessorCount
+	    $ProcessorCount,
+		$UseDynamicMemory,
+		$DynamicMemoryMinBytes,
+		$DynamicMemoryMaxBytes
 	  )
 	  $null = $psboundparameters.remove('ProcessorCount')
+	  $null = $psboundparameters.remove('UseDynamicMemory')
+	  $null = $psboundparameters.remove('DynamicMemoryMinBytes')
+	  $null = $psboundparameters.remove('DynamicMemoryMaxBytes')
+	  $UseDynamicMemory = [Convert]::ToBoolean($UseDynamicMemory)
+
 	  $vm = new-vm @psboundparameters |
 	    Set-Vm -ProcessorCount $ProcessorCount -passthru
-    $vm | Set-VMMemory -DynamicMemoryEnabled $false 
+	  $vm | Set-VMMemory -DynamicMemoryEnabled $UseDynamicMemory -MinimumBytes $DynamicMemoryMinBytes -MaximumBytes $DynamicMemoryMaxBytes
 	  $vm | Start-Vm -passthru |
 	    foreach {
 	      $vm = $_


### PR DESCRIPTION
This adds support for the Dynamic Memory feature added to Hyper-V in Server 2008R2 SP1. It's been useful for me by allowing Hyper-V to give the VMs a little more oomph during the converge/verify stages while scaling the memory footprint back the rest of the time.

Tested on a Windows 8.1 host with 2012R2 virtual machines.
