### PR TITLE
Hyper-V module and Get-VMIP delay fix

### DIFF
--- a/support/hyperv.ps1
+++ b/support/hyperv.ps1
@@ -87,6 +87,7 @@ function New-KitchenVM
 
 function Get-VmIP($vm)
 {
+    start-sleep -seconds 10
     $vm.networkadapters.ipaddresses |
     Where-Object {
         $_ -match '^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$'


### PR DESCRIPTION
Steve, 

I'm submitting changes to fix issue #18, implicit module import, as well as the DHCP delay issue we discussed during troubleshooting.  I did a bit of testing on the timing for the delay.  i was able to avoid the apipa issue at 3 seconds, but set it to 10 seconds to ensure that dhcp had enough time to register.
