### PR TITLE
Add -noprofile to powershell executions to prevent users' custom prof…

### DIFF
--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -45,7 +45,7 @@ module Kitchen
         debug("Loading functions from #{base_script_path}")
         new_script = ". #{base_script_path}; " << script
         debug("Wrapped script: #{new_script}")
-        "#{powershell_64_bit} -encodedcommand #{encode_command new_script} -outputformat Text"
+        "#{powershell_64_bit} -noprofile -encodedcommand #{encode_command new_script} -outputformat Text"
       end
 
       # Convenience method to run a powershell command locally.


### PR DESCRIPTION
Hopefully this helps others. I have a fairly customized Microsoft.PowerShell_profile.ps1 that even spits out a fortune on login. Unfortunately this output will mess with kitchen create and friends since it expects certain outputs that are not fortune. Adding -noprofile seems to fix this issue.
