### PR TITLE
More Configurable VM Networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ driver:
   * The minimum and maximum amount of memory Hyper-V will allocate to a virtual machine if dynamic_memory is enabled. Defaults to 536,870,912 and 2,147,483,648 (512MB-2GB)
 * ip_address
   * IP address for the virtual machine.  If the VM is not on a network with DHCP, this can be used to assign an IP that can be reached from the host machine.
+* subnet
+  * The subnet of the virtual machine. Defaults to `255.255.255.0`
+* gateway
+  * The default gateway of the virtual machine.
+* dns_servers
+  * A list of DNS Servers that can be reached on the virtual network.
 * vm_switch
   * The virtual switch to attach the guest VMs.  Defaults to the first switch returned from Get-VMSwitch.
 * iso_path

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -42,6 +42,9 @@ module Kitchen
       default_config :dynamic_memory, false
       default_config :processor_count, 2
       default_config :ip_address
+      default_config :gateway
+      default_config :dns_servers
+      default_config :subnet, '255.255.255.0'
       default_config :vm_switch
       default_config :iso_path
       default_config :vm_generation, 1

--- a/lib/kitchen/driver/hyperv_version.rb
+++ b/lib/kitchen/driver/hyperv_version.rb
@@ -17,6 +17,6 @@
 
 module Kitchen
   module Driver
-      HYPERV_VERSION = '0.1.10'
+      HYPERV_VERSION = '0.1.20'
   end
 end

--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -128,7 +128,10 @@ module Kitchen
         <<-VMIP
 
           (Get-VM -id "#{@state[:id]}").NetworkAdapters |
-            Set-VMNetworkConfiguration -ipaddress "#{config[:ip_address]}" -subnet 255.255.255.0 |
+            Set-VMNetworkConfiguration -ipaddress "#{config[:ip_address]}" `
+              -subnet "#{config[:subnet]}" `
+              -gateway "#{config[:gateway]}" `
+              -dnsservers #{ruby_array_to_ps_array(config[:dns_servers])} |
             ConvertTo-Json
         VMIP
       end
@@ -178,6 +181,13 @@ module Kitchen
               Write-Error "Source file path does not exist: $sourceLocation"
           } 
         FILECOPY
+      end
+
+      private
+
+      def ruby_array_to_ps_array(list)
+        return "@()" if list.nil? || list.empty?
+        list.to_s.tr('[]','()').prepend('@')
       end
     end
   end

--- a/support/hyperv.ps1
+++ b/support/hyperv.ps1
@@ -113,6 +113,8 @@ Function Set-VMNetworkConfiguration
         [parameter(valuefrompipeline)]
         [object]$NetworkAdapter,
         [String[]]$IPAddress = @(),
+        [String[]]$Gateway = @(),
+        [String[]]$DNSServers = @(),
         [String[]]$Subnet = @()
     )
 
@@ -134,6 +136,8 @@ Function Set-VMNetworkConfiguration
     }
 
     $NetworkSettings[0].IPAddresses = $IPAddress
+    $NetworkSettings[0].DefaultGateways = $Gateway
+    $NetworkSettings[0].DNSServers = $DNSServers
     $NetworkSettings[0].Subnets = $Subnet
     $NetworkSettings[0].ProtocolIFType = 4096
     $NetworkSettings[0].DHCPEnabled = $false


### PR DESCRIPTION
Ahoy! I am an employee at Facebook, Mr. @jaymzh will conduct the final merging should this diff be accepted.

The motivation here is that in our environment we cannot run Hyper-V with a bridged network adapter nor share the connection of the network adapter that can hit the interwebs. Thus, we have to use Hyper-V's NAT setup to get test-kitchen working in our environment. Currently we can't configure additional network settings with this test-kitchen gem so I want to add that functionality in ^_^

Summary:
- Allow configuration of subnet.
  - Defaults to `255.255.255.0`
- Allow configuration of DNS servers.
  - Within `.kitchen.yml` you supply it a list of DNS Servers.
  - If no servers are supplied an empty array is passed to Powershell.
- Allow configuration of gateway.
- Break up `Set-VMNetworkConfiguration` function to be on multiple lines so it is easier on the eyes, aesthetics of backticks notwithstanding.

Sample configuration:

```
...
driver:
  name: hyperv
  vm_switch: NAT
  subnet: 255.255.254.0
  gateway: 192.168.0.1
  dns_servers:
    - 8.8.8.8
    - 4.4.4.4
...
```
