### PR TITLE
adding support for mounting DVD Iso before starting the VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ driver:
   * The virtual switch to attach the guest VMs.  Defaults to the first switch returned from Get-VMSwitch.
 * iso_path
   * Path on the host to the ISO to mount on the VMs.
+* boot_iso_path
+  * Path on the host to the ISO to mount before starting the VMs.
 * vm_generation
   * The generation for the hyper-v VM.  Defaults to 1.
 * disk_type

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -47,6 +47,7 @@ module Kitchen
       default_config :subnet, '255.255.255.0'
       default_config :vm_switch
       default_config :iso_path
+      default_config :boot_iso_path
       default_config :vm_generation, 1
       default_config :disk_type do |driver|
         File.extname(driver[:parent_vhd_name])
@@ -101,7 +102,11 @@ module Kitchen
       def kitchen_vm_path
         @kitchen_vm_path ||= File.join(config[:kitchen_root], ".kitchen/#{instance.name}")
       end
-
+      
+      def boot_iso_path
+        @boot_iso_path ||= config[:boot_iso_path]
+      end
+      
       def differencing_disk_path
         @differencing_disk_path ||= File.join(kitchen_vm_path, "diff" + "#{config[:disk_type]}")
       end

--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -102,6 +102,7 @@ module Kitchen
             UseDynamicMemory = "#{config[:dynamic_memory]}"
             DynamicMemoryMinBytes = #{config[:dynamic_memory_min_bytes]}
             DynamicMemoryMaxBytes = #{config[:dynamic_memory_max_bytes]}
+            boot_iso_path = "#{boot_iso_path}"
           }
           New-KitchenVM @NewVMParams | ConvertTo-Json
         NEWVM

--- a/support/hyperv.ps1
+++ b/support/hyperv.ps1
@@ -68,12 +68,14 @@ function New-KitchenVM
 	    $ProcessorCount,
       $UseDynamicMemory,
       $DynamicMemoryMinBytes,
-      $DynamicMemoryMaxBytes
+      $DynamicMemoryMaxBytes,
+      $boot_iso_path
 	  )
 	  $null = $psboundparameters.remove('ProcessorCount')
 	  $null = $psboundparameters.remove('UseDynamicMemory')
 	  $null = $psboundparameters.remove('DynamicMemoryMinBytes')
 	  $null = $psboundparameters.remove('DynamicMemoryMaxBytes')
+	  $null = $psboundparameters.remove('boot_iso_path')
 	  $UseDynamicMemory = [Convert]::ToBoolean($UseDynamicMemory)
 
 	  $vm = new-vm @psboundparameters |
@@ -84,7 +86,7 @@ function New-KitchenVM
     else {
       $vm | Set-VMMemory -DynamicMemoryEnabled $false
     }
-
+      Mount-VMISO -Id $vm.Id -Path $boot_iso_path
 	  $vm | Start-Vm -passthru |
 	    foreach {
 	      $vm = $_


### PR DESCRIPTION
This current implementation allows to Mount an ISO before the VM is started, convenient when auto-loading unattend.xml on a first Windows boot.
When specifying both iso (boot_iso_path and iso_path), it loads the the first iso, goes through the setup for OOBE, then mounts the iso specified in iso_path.

``` yaml
driver:
  name: hyperv
  parent_vhd_folder: C:\WIN2012R2
  parent_vhd_name: 9600.16415.amd64fre.winblue_refresh.130928-2229_server_serverdatacentereval_en-us.vhd
  boot_iso_path: C:\Unattendxml.iso
  iso_path: C:\AutoUnattendxml.iso
  memory_startup_bytes: 1073741824
```

This is especially helpful when using a raw evaluation image from Microsoft, enabling the configuration of the system without manual input or imaging, for instance using @mwrock 's unattend.xml file here: https://github.com/mwrock/packer-templates/blob/master/answer_files/2012_r2/Autounattend.xml and creating an iso with the powershell function here: https://gallery.technet.microsoft.com/scriptcenter/New-ISOFile-function-a8deeffd
