### PR TITLE
Fix line continuation syntax

### DIFF
--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -87,9 +87,9 @@ module Kitchen
           min = config[:dynamic_memory_min_bytes]
           max = config[:dynamic_memory_max_bytes]
           memory_valid = startup_bytes.between?(min, max)
-          warning = "memory_startup_bytes (#{startup_bytes}) must" /
+          warning = "memory_startup_bytes (#{startup_bytes}) must" \
                     " fall within dynamic memory range (#{min}-#{max})"
-          raise warning  unless memory_valid
+          raise warning unless memory_valid
         end
         config[:vm_switch] = vm_switch
       end
@@ -190,20 +190,6 @@ module Kitchen
       def vhd?
         config[:parent_vhd_name] && File.exist?(parent_vhd_path)
       end
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     end
   end
 end


### PR DESCRIPTION
0ccb2f290009ca90a60c33d6079da41f912d338b introduced a bug that causes kitchen to fail in `validate_vm_settings` when using the dynamic memory option.

```
>>>>>>     Failed to complete #create action: [undefined method `/' for "memory_startup_bytes (1073741824) must":String] on MyConfigName-win2012r2-wmf5
```
