### PR TITLE
Fix mounting iso on Gen 2 VM

### DIFF
--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -136,6 +136,7 @@ module Kitchen
         return unless config[:iso_path]
         info("Mounting #{config[:iso_path]}")
         run_ps mount_vm_iso
+        info("Done mounting #{config[:iso_path]}")
       end
 
       def copy_vm_files

--- a/lib/kitchen/driver/hyperv_version.rb
+++ b/lib/kitchen/driver/hyperv_version.rb
@@ -17,6 +17,6 @@
 
 module Kitchen
   module Driver
-    HYPERV_VERSION = '0.2.3'.freeze
+    HYPERV_VERSION = '0.2.4'.freeze
   end
 end

--- a/support/hyperv.ps1
+++ b/support/hyperv.ps1
@@ -217,6 +217,11 @@ function Mount-VMISO
     [cmdletbinding()]
     param($Id, $Path)
 
-    set-VMDvdDrive -VMName (Get-VM -Id $Id).Name -Path $Path
+    if ((Get-VM -Id $Id).Generation -eq 2)
+    {
+        Add-VMDvdDrive (Get-VM -Id $Id).Name | Set-VMDvdDrive -VMName (Get-VM -Id $Id).Name -Path $Path
+    }
+
+    Set-VMDvdDrive -VMName (Get-VM -Id $Id).Name -Path $Path
 }
 


### PR DESCRIPTION
Generation 2 VMs don't have DVD drive by default, hence Add-VMDvdDrive command needs to be executed initially. 