### PR TITLE
Support setting VM notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ driver:
   * Enable the Hyper-V Integration Guest services for the VM before starting it. Hyper-V defauls is false (true|false)
 * disk_type
   * The type of virtual disk to create, .VHD or .VHDX.  Defaults to the file extension of the parent virtual hard drive.
-* Note
+* vm_note
   * A note to add to the VM's note field. Defaults to empty.
 
 ## Image Configuration

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ driver:
   * Enable the Hyper-V Integration Guest services for the VM before starting it. Hyper-V defauls is false (true|false)
 * disk_type
   * The type of virtual disk to create, .VHD or .VHDX.  Defaults to the file extension of the parent virtual hard drive.
+* Note
+  * A note to add to the VM's note field. Defaults to empty.
 
 ## Image Configuration
 

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -60,9 +60,9 @@ module Kitchen
       def create(state)
         @state = state
         validate_vm_settings
-        set_virtual_machine_note
         create_new_differencing_disk
         create_virtual_machine
+        set_virtual_machine_note
         update_state
         mount_virtual_machine_iso
         instance.transport.connection(@state).wait_until_ready

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -49,6 +49,7 @@ module Kitchen
       default_config :iso_path
       default_config :boot_iso_path
       default_config :enable_guest_services
+      default_config :vm_note
       default_config :vm_generation, 1
       default_config :disk_type do |driver|
         File.extname(driver[:parent_vhd_name])
@@ -65,6 +66,7 @@ module Kitchen
         mount_virtual_machine_iso
         instance.transport.connection(@state).wait_until_ready
         copy_vm_files
+        set_virtual_machine_note
         info("Hyper-V instance #{instance.to_str} created.")
       end
 
@@ -136,6 +138,11 @@ module Kitchen
         return unless config[:iso_path]
         info("Mounting #{config[:iso_path]}")
         run_ps mount_vm_iso
+      end
+      def set_virtual_machine_note
+        return unless config[:vm_note]
+        info("Adding note to VM: #{config[:vm_note]}")
+        run_ps set_vm_note
       end
 
       def copy_vm_files

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -60,13 +60,13 @@ module Kitchen
       def create(state)
         @state = state
         validate_vm_settings
+        set_virtual_machine_note
         create_new_differencing_disk
         create_virtual_machine
         update_state
         mount_virtual_machine_iso
         instance.transport.connection(@state).wait_until_ready
         copy_vm_files
-        set_virtual_machine_note
         info("Hyper-V instance #{instance.to_str} created.")
       end
 
@@ -141,7 +141,7 @@ module Kitchen
       end
       def set_virtual_machine_note
         return unless config[:vm_note]
-        info("Adding note to VM: #{config[:vm_note]}")
+        info("Adding note to VM: '#{config[:vm_note]}'")
         run_ps set_vm_note
       end
 

--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -160,9 +160,9 @@ module Kitchen
       end
 
       def set_vm_note
-        <<-MOUNTISO
+        <<-VMNOTE
           Set-VM -Name (Get-VM | Where-Object{ $_.ID -eq "#{@state[:id]}"}).Name -Note "#{config[:vm_note]}"
-        MOUNTISO
+        VMNOTE
       end
 
       def copy_vm_file_ps(source, dest)

--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -159,6 +159,12 @@ module Kitchen
         MOUNTISO
       end
 
+      def set_vm_note
+        <<-MOUNTISO
+          Set-VM -Name "#{@state[:id]}" -Note #{config[:vm_note]}
+        MOUNTISO
+      end
+
       def copy_vm_file_ps(source, dest)
         <<-FILECOPY
           Function CopyFile ($VM, [string]$SourcePath, [string]$DestPath) {

--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -161,7 +161,7 @@ module Kitchen
 
       def set_vm_note
         <<-MOUNTISO
-          Set-VM -Name "#{@state[:id]}" -Note #{config[:vm_note]}
+          Set-VM -Name (Get-VM | Where-Object{ $_.ID -eq "#{@state[:id]}"}).Name -Note "#{config[:vm_note]}"
         MOUNTISO
       end
 


### PR DESCRIPTION
I added the ability to add some info to the hyperv notes field through .kitchen.yml

We have a couple hosts that runs test-kitchen like a CI for us, we often have a few VM's running at a time on that host through kitchen. It's nice to be able to add a bit of extra info (IE the git commit the VM belongs to) about the machine to help identify which build the VM belongs to from the hyper-v interface.