### PR TITLE
Add ability to resize a the VHD when the disk is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ driver:
   * Enable the Hyper-V Integration Guest services for the VM before starting it. Hyper-V defauls is false (true|false)
 * disk_type
   * The type of virtual disk to create, .VHD or .VHDX.  Defaults to the file extension of the parent virtual hard drive.
+* resize_vhd
+  * Resize the disk to the specified size. Leave empty to keep the original size. Defaults to empty.
 * vm_note
   * A note to add to the VM's note field. Defaults to empty.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ driver:
 * disk_type
   * The type of virtual disk to create, .VHD or .VHDX.  Defaults to the file extension of the parent virtual hard drive.
 * resize_vhd
-  * Resize the disk to the specified size. Leave empty to keep the original size. Defaults to empty.
+  * Resize the disk to the specified size. Leave empty to keep the original size. Only works on newly created VM's. Defaults to empty.
 * vm_note
   * A note to add to the VM's note field. Defaults to empty.
 

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -62,7 +62,6 @@ module Kitchen
         @state = state
         validate_vm_settings
         create_new_differencing_disk
-        set_new_vhd_size
         create_virtual_machine
         set_virtual_machine_note
         update_state
@@ -104,6 +103,7 @@ module Kitchen
         info("Creating differencing disk for #{instance.name}.")
         run_ps new_differencing_disk_ps
         info("Created differencing disk for #{instance.name}.")
+        set_new_vhd_size
       end
 
       def vm_switch

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -147,6 +147,7 @@ module Kitchen
         return unless config[:resize_vhd]
         info("Resizing differencing disk for #{instance.name}.")
         run_ps resize_vhd
+        info("Resized differencing disk for #{instance.name}.")
       end
 
       def set_virtual_machine_note

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -50,6 +50,7 @@ module Kitchen
       default_config :boot_iso_path
       default_config :enable_guest_services
       default_config :vm_note
+      default_config :resize_vhd
       default_config :vm_generation, 1
       default_config :disk_type do |driver|
         File.extname(driver[:parent_vhd_name])
@@ -61,6 +62,7 @@ module Kitchen
         @state = state
         validate_vm_settings
         create_new_differencing_disk
+        set_new_vhd_size
         create_virtual_machine
         set_virtual_machine_note
         update_state
@@ -140,6 +142,13 @@ module Kitchen
         run_ps mount_vm_iso
         info("Done mounting #{config[:iso_path]}")
       end
+
+      def set_new_vhd_size
+        return unless config[:resize_vhd]
+        info("Resizing differencing disk for #{instance.name}.")
+        run_ps resize_vhd
+      end
+
       def set_virtual_machine_note
         return unless config[:vm_note]
         info("Adding note to VM: '#{config[:vm_note]}'")

--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -161,7 +161,7 @@ module Kitchen
 
       def resize_vhd
         <<-VMNOTE
-          Resize-VHD -Path "#{parent_vhd_path}" -SizeBytes "#{config[:resize_vhd]}"
+          Resize-VHD -Path "#{parent_vhd_path}" -Size "#{config[:resize_vhd]}"
         VMNOTE
       end
 

--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -159,6 +159,12 @@ module Kitchen
         MOUNTISO
       end
 
+      def resize_vhd
+        <<-VMNOTE
+          Resize-VHD -Path "#{parent_vhd_path}" -SizeBytes "#{config[:resize_vhd]}"
+        VMNOTE
+      end
+
       def set_vm_note
         <<-VMNOTE
           Set-VM -Name (Get-VM | Where-Object{ $_.ID -eq "#{@state[:id]}"}).Name -Note "#{config[:vm_note]}"

--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -161,7 +161,7 @@ module Kitchen
 
       def resize_vhd
         <<-VMNOTE
-          Resize-VHD -Path "#{parent_vhd_path}" -Size "#{config[:resize_vhd]}"
+          Resize-VHD -Path "#{parent_vhd_path}" -Size #{config[:resize_vhd]}
         VMNOTE
       end
 


### PR DESCRIPTION
We reuse the images we create with test-kitchen, one of the images we created is for an artifact server that needs a huge disk size. Our base images are very small so we need to resize the image before converging.

I added an optional parameter that resizes the VHD after the differentiating disk is created. It won't update existing VM's, but it will resize new VM's.

The VM won't be able to use the new space until the disk is expanded (I have a cookbook in the works for that) but the image is resized correctly.