### PR TITLE
Static Mac Address

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ driver:
 * copy_vm_files
   * An array of hashes (`source` and `dest`) of files or directories to copy over to the sytem under test.
   * example: 
+* static_mac_address
+  * String value specifying a static MAC Address to be set at virtual machine creation time.  
+  * Hyper-V will automatically assign a valid dynamic address if your input doesn't give a valid MAC Address.  
+  * example: static_mac_address: '00155d123456'
   
 ```
 driver:

--- a/README.md
+++ b/README.md
@@ -92,10 +92,6 @@ driver:
 * copy_vm_files
   * An array of hashes (`source` and `dest`) of files or directories to copy over to the sytem under test.
   * example: 
-* static_mac_address
-  * String value specifying a static MAC Address to be set at virtual machine creation time.  
-  * Hyper-V will automatically assign a valid dynamic address if your input doesn't give a valid MAC Address.  
-  * example: `static_mac_address: '00155d123456'`
   
 ```
 driver:
@@ -104,6 +100,11 @@ driver:
     - source: c:/users/steven/downloads/chef-client-12.19.36-1-x64.msi
       dest: c:/users/administrator/appdata/local/temp/chef-client-12.19.36-1-x64.msi
 ```
+
+* static_mac_address
+  * String value specifying a static MAC Address to be set at virtual machine creation time.  
+  * Hyper-V will automatically assign a valid dynamic address if your input doesn't give a valid MAC Address.  
+  * example: `static_mac_address: '00155d123456'`
 
 
 ## Image Configuration

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ driver:
 * static_mac_address
   * String value specifying a static MAC Address to be set at virtual machine creation time.  
   * Hyper-V will automatically assign a valid dynamic address if your input doesn't give a valid MAC Address.  
-  * example: static_mac_address: '00155d123456'
+  * example: `static_mac_address: '00155d123456'`
   
 ```
 driver:

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -55,6 +55,7 @@ module Kitchen
       default_config :additional_disks
       default_config :vm_generation, 1
       default_config :disable_secureboot, false
+      default_config :static_mac_address
       default_config :disk_type do |driver|
         File.extname(driver[:parent_vhd_name])
       end

--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -112,6 +112,7 @@ module Kitchen
             Generation = #{config[:vm_generation]}
             DisableSecureBoot = "#{config[:disable_secureboot]}"
             MemoryStartupBytes = #{config[:memory_startup_bytes]}
+            StaticMacAddress = "#{config[:static_mac_address]}"
             Name = "#{instance.name}"
             Path = "#{kitchen_vm_path}"
             VHDPath = "#{differencing_disk_path}"

--- a/spec/support/hyperv.Tests.ps1
+++ b/spec/support/hyperv.Tests.ps1
@@ -158,3 +158,37 @@ Describe "New-KitchenVM with DisableSecureBoot" {
         }
     }
 }
+
+Describe "New-KitchenVM with StaticMacAddress" {
+    function New-VM {}
+    function Set-VM {}
+    function Set-VMMemory {}
+    function Set-VMNetworkAdapter {param ($VM, $StaticMacAddress)}
+    function Start-VM {}
+  
+    Mock New-VM
+    Mock Set-VM
+    Mock Set-VMMemory
+    Mock Set-VMNetworkAdapter
+    Mock Start-VM
+
+    Context "When StaticMacAddress is not specified" {
+        New-KitchenVM
+
+        It "Should not set the StaticMacAddress for the VM" {
+            Assert-MockCalled Set-VMNetworkAdapter -Times 0
+        }
+    }
+
+    Context "When StaticMacAddress is specified" {
+        $testStaticMacAddress = $StaticMacAddress
+        New-KitchenVM -StaticMacAddress $StaticMacAddress
+
+        It "Should set the StaticMacAddress for the VM" {
+            Assert-MockCalled Set-VMNetworkAdapter -Times 1 -ParameterFilter {
+                $VM -eq $null -and 
+                $StaticMacAddress -eq $testStaticMacAddress
+            }
+        }
+    }
+}

--- a/support/hyperv.ps1
+++ b/support/hyperv.ps1
@@ -59,6 +59,7 @@ function New-KitchenVM {
         $Generation = 1,
         $DisableSecureBoot,
         $MemoryStartupBytes,
+        $StaticMacAddress,
         $Name,
         $Path,
         $VHDPath,
@@ -74,6 +75,7 @@ function New-KitchenVM {
     )
     $null = $psboundparameters.remove('DisableSecureBoot')    
     $null = $psboundparameters.remove('ProcessorCount')
+    $null = $psboundparameters.remove('StaticMacAddress') 
     $null = $psboundparameters.remove('UseDynamicMemory')
     $null = $psboundparameters.remove('DynamicMemoryMinBytes')
     $null = $psboundparameters.remove('DynamicMemoryMaxBytes')
@@ -96,6 +98,9 @@ function New-KitchenVM {
     }
     if (-not [string]::IsNullOrEmpty($boot_iso_path)) {
         Mount-VMISO -Id $vm.Id -Path $boot_iso_path
+    }
+    if ($StaticMacAddress -ne $null) {
+        Set-VMNetworkAdapter -VMName $vm.VMName -StaticMacAddress $StaticMacAddress
     }
     if ($EnableGuestServices -and (Get-command Enable-VMIntegrationService -ErrorAction SilentlyContinue)) {
         Enable-VMIntegrationService -VM $vm -Name 'Guest Service Interface'


### PR DESCRIPTION
Added functionality to set a static mac address in the .kitchen.yml file.  I needed this due to our environment having a cap on mac addresses per port on the switch, and this allows the user to set a valid mac address for their test kitchen machines so they don't have to worry about having the port reset all the time from new VMs that are spun up constantly.

There is no real input testing against the value in the field because Hyper-V appears to just set a dynamic address anyways if an invalid mac is provided.