### PR TITLE
Added static_mac_address feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ driver:
       dest: c:/users/administrator/appdata/local/temp/chef-client-12.19.36-1-x64.msi
 ```
 
+* static_mac_address
+  * String value specifying a static MAC Address to be set at virtual machine creation time.  
+  * Hyper-V will automatically assign a valid dynamic address if your input doesn't give a valid MAC Address.  
+  * example: `static_mac_address: '00155d123456'`
+
 
 ## Image Configuration
 

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -55,6 +55,7 @@ module Kitchen
       default_config :additional_disks
       default_config :vm_generation, 1
       default_config :disable_secureboot, false
+      default_config :static_mac_address
       default_config :disk_type do |driver|
         File.extname(driver[:parent_vhd_name])
       end

--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -112,6 +112,7 @@ module Kitchen
             Generation = #{config[:vm_generation]}
             DisableSecureBoot = "#{config[:disable_secureboot]}"
             MemoryStartupBytes = #{config[:memory_startup_bytes]}
+            StaticMacAddress = "#{config[:static_mac_address]}"
             Name = "#{instance.name}"
             Path = "#{kitchen_vm_path}"
             VHDPath = "#{differencing_disk_path}"

--- a/spec/support/hyperv.Tests.ps1
+++ b/spec/support/hyperv.Tests.ps1
@@ -173,20 +173,20 @@ Describe "New-KitchenVM with StaticMacAddress" {
     Mock Start-VM
 
     Context "When StaticMacAddress is not specified" {
-        New-KitchenVM
+        New-KitchenVM -StaticMacAddress ""
 
         It "Should not set the StaticMacAddress for the VM" {
-            Assert-MockCalled Set-VMNetworkAdapter -Times 0
+            Assert-MockCalled Set-VMNetworkAdapter -Times 1
         }
     }
 
     Context "When StaticMacAddress is specified" {
-        $testStaticMacAddress = $StaticMacAddress
-        New-KitchenVM -StaticMacAddress $StaticMacAddress
+        $testStaticMacAddress = "00155D01B532"
+        New-KitchenVM -StaticMacAddress $testStaticMacAddress
 
         It "Should set the StaticMacAddress for the VM" {
             Assert-MockCalled Set-VMNetworkAdapter -Times 1 -ParameterFilter {
-                $VM -eq $null -and 
+                $VM -eq $VM.VMName -and 
                 $StaticMacAddress -eq $testStaticMacAddress
             }
         }

--- a/spec/support/hyperv.Tests.ps1
+++ b/spec/support/hyperv.Tests.ps1
@@ -158,3 +158,37 @@ Describe "New-KitchenVM with DisableSecureBoot" {
         }
     }
 }
+
+Describe "New-KitchenVM with StaticMacAddress" {
+    function New-VM {}
+    function Set-VM {}
+    function Set-VMMemory {}
+    function Set-VMNetworkAdapter {param ($VM, $StaticMacAddress)}
+    function Start-VM {}
+  
+    Mock New-VM
+    Mock Set-VM
+    Mock Set-VMMemory
+    Mock Set-VMNetworkAdapter
+    Mock Start-VM
+
+    Context "When StaticMacAddress is not specified" {
+        New-KitchenVM
+
+        It "Should not set the StaticMacAddress for the VM" {
+            Assert-MockCalled Set-VMNetworkAdapter -Times 0
+        }
+    }
+
+    Context "When StaticMacAddress is specified" {
+        $testStaticMacAddress = $StaticMacAddress
+        New-KitchenVM -StaticMacAddress $StaticMacAddress
+
+        It "Should set the StaticMacAddress for the VM" {
+            Assert-MockCalled Set-VMNetworkAdapter -Times 1 -ParameterFilter {
+                $VM -eq $null -and 
+                $StaticMacAddress -eq $testStaticMacAddress
+            }
+        }
+    }
+}

--- a/support/hyperv.ps1
+++ b/support/hyperv.ps1
@@ -59,6 +59,7 @@ function New-KitchenVM {
         $Generation = 1,
         $DisableSecureBoot,
         $MemoryStartupBytes,
+        $StaticMacAddress,
         $Name,
         $Path,
         $VHDPath,
@@ -74,6 +75,7 @@ function New-KitchenVM {
     )
     $null = $psboundparameters.remove('DisableSecureBoot')    
     $null = $psboundparameters.remove('ProcessorCount')
+    $null = $psboundparameters.remove('StaticMacAddress') 
     $null = $psboundparameters.remove('UseDynamicMemory')
     $null = $psboundparameters.remove('DynamicMemoryMinBytes')
     $null = $psboundparameters.remove('DynamicMemoryMaxBytes')
@@ -96,6 +98,9 @@ function New-KitchenVM {
     }
     if (-not [string]::IsNullOrEmpty($boot_iso_path)) {
         Mount-VMISO -Id $vm.Id -Path $boot_iso_path
+    }
+    if ($StaticMacAddress -ne $null) {
+        Set-VMNetworkAdapter -VMName $vm.VMName -StaticMacAddress $StaticMacAddress
     }
     if ($EnableGuestServices -and (Get-command Enable-VMIntegrationService -ErrorAction SilentlyContinue)) {
         Enable-VMIntegrationService -VM $vm -Name 'Guest Service Interface'


### PR DESCRIPTION
Feature to add the ability to specify a static mac address in the kitchen.yml file.  I needed this due to restrictions on devices per port on our switches.  With this, I can reuse the same mac address on all my test kitchen VMs and not get one blocked due to a port violation of a "new device" on the port.

There is no testing of the input to verify it is a good mac address, because hyperv will automatically divert back to dynamic if the input isn't a valid mac address.