### PR TITLE
Fixed issue with existing stale diff disk

### DIFF
--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -113,7 +113,14 @@ module Kitchen
       end
 
       def create_new_differencing_disk
-        return if File.exist? differencing_disk_path
+        if File.exist? differencing_disk_path
+          if vm_exists_silent
+            return
+          else
+            info ('Found existing differencing disk with no existing VM.  Removing differencing disk.')
+            FileUtils.rm(differencing_disk_path)
+          end
+        end
         info("Creating differencing disk for #{instance.name}.")
         run_ps new_differencing_disk_ps
         info("Created differencing disk for #{instance.name}.")
@@ -201,6 +208,13 @@ module Kitchen
         existing_vm = run_ps ensure_vm_running_ps
         return false if existing_vm.nil? || existing_vm['Id'].nil?
         info("Found an exising VM with an ID: #{existing_vm['Id']}")
+        true
+      end
+
+      def vm_exists_silent
+        return false unless @state.key?(:id) && !@state[:id].nil?
+        existing_vm = run_ps ensure_vm_running_ps
+        return false if existing_vm.nil? || existing_vm['Id'].nil?
         true
       end
 


### PR DESCRIPTION
Found a bug related to having a stale differencing disk in the default location.  If a differencing disk has been made, and doesn't get destroyed for whatever reason, and then becomes out of date due to some change on the parent drive, kitchen create will fail out due to not being able to attach the drive.  

This fix adds in some conditional logic at the create differencing disk level to test if a disk is already present, and if so, tests if a VM is also present.  If so, it breaks out of the function, just as it did prior to.  However, if there is a differencing disk, and no VM present, it will delete the existing disk, then proceed to create a new one.  This logic has solved my problem of being unable to use kitchen create sometimes when an existing diff disk was already present due to it being stale from the master disk.