### PR TITLE
Change resize_vhd parameter to -SizeBytes

### DIFF
--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -179,7 +179,7 @@ module Kitchen
 
       def resize_vhd
         <<-VMNOTE
-          Resize-VHD -Path "#{parent_vhd_path}" -Size #{config[:resize_vhd]}
+          Resize-VHD -Path "#{parent_vhd_path}" -SizeBytes #{config[:resize_vhd]}
         VMNOTE
       end
 


### PR DESCRIPTION
Bug fix for issue #57, tested on my local machine and appears to be working after the change from -Size to -SizeBytes.  Verified with Microsoft documentation that -Size isn't a parameter.

https://technet.microsoft.com/en-us/itpro/powershell/windows/hyper-v/resize-vhd