### PR TITLE
Added quotes around variable for Get-DefaultVMSwitch

### DIFF
--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -167,7 +167,7 @@ module Kitchen
 
       def vm_default_switch_ps
         <<-VMSWITCH
-          Get-DefaultVMSwitch #{config[:vm_switch]} | ConvertTo-Json
+          Get-DefaultVMSwitch "#{config[:vm_switch]}" | ConvertTo-Json
         VMSWITCH
       end
 


### PR DESCRIPTION
I was unable to recreate the **exact** error in Issue #59 even after creating a local user "Current User", a recipe inside that users directory structure, a VM with spaces in the `parent_vhd_name` & `parent_vhd_folder`.  I tried both with quotes and without quotes in my kitchen.yml file.  

However, I could create a very similar error based on the fact that the issue error referenced `Get-DefaultVMSwitch` as well as the user directory structure.  That code did in fact not have quotes around the variable, so by creating a switch with a space in it, and leaving out the quotes in my kitchen.yml I got the following error, which is only missing the reference to the user directory having spaces in it.

```
>>>>>> Message: 1 actions failed.
>>>>>>     Failed to complete #create action: [Failed: #< CLIXML
<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0
"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"
><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></
PR></MS></Obj><S S="Error">Get-DefaultVMSwitch : A positional parameter cannot be found that accepts argument 'Switch'._
x000D__x000A_</S><S S="Error">At line:2 char:11_x000D__x000A_</S><S S="Error">+           Get-DefaultVMSwitch HyperV Swi
tch | ConvertTo-Json_x000D__x000A_</S><S S="Error">+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~_x000D__x000A_</S><S S="
Error">    + CategoryInfo          : InvalidArgument: (:) [Get-DefaultVMSwitch], ParameterBindingException_x000D__x000A_
</S><S S="Error">    + FullyQualifiedErrorId : PositionalParameterNotFound,Get-DefaultVMSwitch_x000D__x000A_</S><S S="Er
ror"> _x000D__x000A_</S></Objs>] on default-centos-73
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration

```
I believe this is ultimately the error that needs fixing presented by Issue #59 and by adding quotes, the `vm_switch` in the kitchen.yml no longer requires quotes for one with spaces.  