### PR TITLE
Get parent VM generation if none are specified in kitchen.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ driver:
 * boot_iso_path
   * Path on the host to the ISO to mount before starting the VMs.
 * vm_generation
-  * The generation for the hyper-v VM.  Defaults to 1.
+  * The generation for the hyper-v VM.  Defaults to 1 if not specified or no parent VM generation found.
 * disable_secureboot
   * Boolean.  If true, will disable secure boot for the VM.  Only applies if `vm_generation=2`.  Defaults to false.
 * enable_guest_services

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -25,12 +25,9 @@ require 'fileutils'
 require 'JSON'
 
 module Kitchen
-
   module Driver
-
     # Driver for Hyper-V
     class Hyperv < Kitchen::Driver::Base
-
       kitchen_driver_api_version 2
       plugin_version Kitchen::Driver::HYPERV_VERSION
 
@@ -53,7 +50,7 @@ module Kitchen
       default_config :vm_note
       default_config :resize_vhd
       default_config :additional_disks
-      default_config :vm_generation, 1
+      default_config :vm_generation
       default_config :disable_secureboot, false
       default_config :static_mac_address
       default_config :disk_type do |driver|
@@ -113,6 +110,9 @@ module Kitchen
           vm_vlan_id_warning = "vm_vlan_id (#{vm_vlan_id}) must be a valid 802.1Q" \
                                " VLAN ID between (#{vm_vlan_id_min}-#{vm_vlan_id_max})"
           raise vm_vlan_id_warning unless vm_vlan_id_valid
+        end
+        if config[:vm_generation].nil?
+          set_vm_generation
         end
       end
 
@@ -245,6 +245,14 @@ module Kitchen
             info("Removed additional disk #{additional_disk[:name]} for #{instance.name}.")
           end
         end
+      end
+
+      def set_vm_generation
+        vm_generation_object = run_ps vm_generation_ps
+        if vm_generation_object.nil? #|| vm_generation_object['Generation'].nil?
+          raise 'No Generation Returned'
+        end
+        config[:vm_generation] = vm_generation_object['Generation']
       end
 
       def kitchen_vm_path

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -249,8 +249,9 @@ module Kitchen
 
       def set_vm_generation
         vm_generation_object = run_ps vm_generation_ps
-        if vm_generation_object.nil? #|| vm_generation_object['Generation'].nil?
-          raise 'No Generation Returned'
+        if vm_generation_object.nil?
+          info("Didn't find a parent VM generation, defaulting to 1")
+          config[:vm_generation] = 1
         end
         config[:vm_generation] = vm_generation_object['Generation']
       end

--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -189,6 +189,12 @@ module Kitchen
         VMNOTE
       end
 
+      def vm_generation_ps
+        <<-VMGENERATION
+          Get-VMGeneration -ParentPath "#{parent_vhd_path}" | ConvertTo-Json
+        VMGENERATION
+      end
+
       def copy_vm_file_ps(source, dest)
         <<-FILECOPY
           Function CopyFile ($VM, [string]$SourcePath, [string]$DestPath) {

--- a/support/hyperv.ps1
+++ b/support/hyperv.ps1
@@ -53,6 +53,31 @@ function Assert-VmRunning {
     $Output
 }
 
+function Get-VMGeneration {
+    [cmdletbinding()]
+    param(
+        [parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]    
+        [string[]]$ParentPath
+    )
+
+    $parent_location = "$ParentPath"
+    $parent_location = $parent_location.Replace("/", "\")
+    $virtualMachines = Get-VM | Select-Object Name, Generation, VMId
+
+    ForEach ($vm in $virtualMachines) {
+        $vhd = $vm.VMId | Get-VHD
+
+        if (($vhd.Path -eq $parent_location) -or ($vhd.ParentPath -eq $parent_location)) {
+            $parentVM = $vm.Name
+            $Output = Get-VM -Name $parentVM | Select-Object Generation
+            break
+        }
+    }
+    $Output
+}
+
+
 function New-KitchenVM {
     [cmdletbinding()]
     param (


### PR DESCRIPTION
This code will do the work of getting the parent VM generation for creating the new machine, if one is not specified in the kitchen.yml.  This works in the case of both no checkpoints, or checkpoints on the parent VM.  

It also respects the generation specified in the kitchen.yml if there is one.  This way, if someone accidentally forgets that line and is running a generation 2 machine, the machine wont create and inexplicably not boot without any good information. 