### PR TITLE
Disable automatic snapshots

### DIFF
--- a/support/hyperv.ps1
+++ b/support/hyperv.ps1
@@ -116,6 +116,9 @@ function New-KitchenVM {
     if ($DisableSecureBoot -and ($Generation -eq 2) -and (Get-command Set-VMFirmware -ErrorAction SilentlyContinue)) {
         Set-VMFirmware -VM $vm -EnableSecureBoot Off
     }
+    if ((Get-Command -Name Set-Vm).Parameters["AutomaticCheckpointsEnabled"]) {
+        Set-VM -Name $vm.VMName -AutomaticCheckpointsEnabled $false
+    }
     $vm | Start-Vm -passthru |
         foreach {
         $vm = $_


### PR DESCRIPTION
Fix for #62. The code will disable automatic snapshots by setting a vm's AutomaticCheckpointsEnabled to $false after a vm is created, but before it is started. This is only performed if the Hyper-V version of Set-VM supports the parameter.