### PR TITLE
update set_vm_ipaddress_ps to wait for "ok" status

### DIFF
--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -156,6 +156,10 @@ module Kitchen
       def set_vm_ipaddress_ps
         <<-VMIP
 
+          while ((Get-VM -id "#{@state[:id]}").NetworkAdapters[0].Status -ne 'Ok'){
+            start-sleep 10
+          }
+          
           (Get-VM -id "#{@state[:id]}").NetworkAdapters |
             Set-VMNetworkConfiguration -ipaddress "#{config[:ip_address]}" `
               -subnet "#{config[:subnet]}" `


### PR DESCRIPTION
Was experiencing an issue where a Win2016 VM on HyperV wouldn't complete the Set-VMNetworkConfiguration in time and the VM would end up with a 169.x.x.x address.  I added a "wait for Status -eq 'OK'" to set_vm_ipaddress_ps and now I get the correct address is added to the VM once the network adapters have loaded.  

Tested on Hyper-V Win2016 Guest: v1607
Hyper-V Host:  Win10 v1703
ChefDK: 2.5.3
Kitchen: 1.20.0