### PR TITLE
Fix case sensitivity issue in require

### DIFF
--- a/kitchen-hyperv.gemspec
+++ b/kitchen-hyperv.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Hyper-V Driver for Test-Kitchen'
   spec.description   = 'Hyper-V Driver for Test-Kitchen'
   spec.homepage      = "https://github.com/test-kitchen/kitchen-hyperv"
-  spec.license       = "Apache 2"
+  spec.license       = "Apache-2.0"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -22,7 +22,7 @@ require 'kitchen/driver/hyperv_version'
 require 'kitchen/driver/powershell'
 require 'mixlib/shellout'
 require 'fileutils'
-require 'JSON'
+require 'json'
 
 module Kitchen
 

--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -17,7 +17,7 @@
 
 require 'mixlib/shellout'
 require 'fileutils'
-require 'JSON'
+require 'json'
 
 module Kitchen
   module Driver


### PR DESCRIPTION
- JSON gem is not defined properly for running in a case sensitive environment.
  i.e. Linux subsystem for windows or if windows has case sensitivity turned on.
- fixed Apache license version to meet on of the accepted gem values