### PR TITLE
Add `password` option for transport section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,15 @@ driver:
 
 ### Required parameters:
 
+#### Driver Parameters
 * parent_vhd_folder
   * Location of the base vhd files
 * parent_vhd_name
   * Vhd file name for the base vhd file
+
+#### Transport Parameters
+* password
+  * Password used to connect to the instance
 
 ### Optional parameters:
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ driver:
 
 ### Required parameters:
 
-#### Driver Parameters
+#### Driver parameters
 * parent_vhd_folder
   * Location of the base vhd files
 * parent_vhd_name
   * Vhd file name for the base vhd file
 
-#### Transport Parameters
+#### Transport parameters
 * password
   * Password used to connect to the instance
 


### PR DESCRIPTION
This is technically not applicable since this is a driver, but adding it will potentially avoid someone having to search for the resolution to the 'password is a required option' error.
