### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ desc "Run all quality tasks"
 task quality: :style
 
 begin
-  require "yard"
+  require "yard" unless defined?(YARD)
   YARD::Rake::YardocTask.new
 rescue LoadError
   puts "yard is not available. (sudo) gem install yard to generate yard documentation."

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -20,9 +20,9 @@ require "kitchen"
 require "kitchen/driver"
 require_relative "hyperv_version"
 require_relative "powershell"
-require "mixlib/shellout"
-require "fileutils"
-require "json"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
+require "fileutils" unless defined?(FileUtils)
+require "json" unless defined?(JSON)
 
 module Kitchen
 

--- a/lib/kitchen/driver/powershell.rb
+++ b/lib/kitchen/driver/powershell.rb
@@ -15,9 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "mixlib/shellout"
-require "fileutils"
-require "json"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
+require "fileutils" unless defined?(FileUtils)
+require "json" unless defined?(JSON)
 
 module Kitchen
   module Driver

--- a/spec/kitchen/driver/hyperv_spec.rb
+++ b/spec/kitchen/driver/hyperv_spec.rb
@@ -19,7 +19,7 @@
 require_relative "../../spec_helper"
 
 require "logger"
-require "stringio"
+require "stringio" unless defined?(StringIO)
 require "kitchen"
 require "kitchen/driver/hyperv_version"
 require "kitchen/driver/hyperv"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,4 +40,4 @@ require "minitest"
 require "minitest/stub_const"
 require "minitest/autorun"
 require "mocha/setup"
-require "tempfile"
+require "tempfile" unless defined?(Tempfile)


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>