### PR TITLE
Add support for remote Hyper-V; Fix style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
 
 Style/Documentation:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ driver:
     * type
       * The type of virtual disk to create, .VHD or .VHDX.  Defaults to the file extension of the parent virtual hard drive.
   * Example:
-  
+
 ```yaml
 driver:
   name: hyperv
@@ -110,7 +110,7 @@ driver:
 * copy_vm_files
   * An array of hashes (`source` and `dest`) of files or directories to copy over to the system under test. Requires enable_guest_services to be true.
   * example:
-  
+
 ```yaml
 driver:
   name: hyperv
@@ -120,8 +120,8 @@ driver:
 ```
 
 * static_mac_address
-  * String value specifying a static MAC Address to be set at virtual machine creation time.  
-  * Hyper-V will automatically assign a valid dynamic address if your input doesn't give a valid MAC Address.  
+  * String value specifying a static MAC Address to be set at virtual machine creation time.
+  * Hyper-V will automatically assign a valid dynamic address if your input doesn't give a valid MAC Address.
   * example: `static_mac_address: '00155d123456'`
 
 ## Image Configuration
@@ -133,6 +133,22 @@ driver:
  Ubuntu and other Linux virtual machines may require installation of cloud tools to allow Hyper-V to determine the virtual machine's IP.
 
 * Resolved by installing linux cloud tools. See <https://stackoverflow.com/a/33059342>
+
+## Using Remote Hyper-V Servers
+
+You can use a remote Hyper-V installation with this driver. For this you need to set:
+
+- `hyperv_server` as the IP or FQDN of the server
+- `hyperv_username`
+- `hyperv_password`
+
+All PowerShell commands to create and manage the VM will then be forwarded via WinRM by the Train framework. The accompanying `hyperv.ps1` helper script will be uploaded on the first connection.
+
+### Optional Parameters
+
+- `hyperv_ssl` (default: `false`) controls if the connection should be encrypted
+- `hyperv_insecure` (default: `true`) sets if self-signed certificates should be accepted
+- `remote_vm_path` (default: `C:\Users\Public\Documents\Hyper-V`) to specify where VMs should be stored
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require "bundler/gem_tasks"
 require "kitchen/driver/hyperv_version"
 

--- a/kitchen-hyperv.gemspec
+++ b/kitchen-hyperv.gemspec
@@ -1,5 +1,4 @@
-# encoding: utf-8
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require "kitchen/driver/hyperv_version"
@@ -24,4 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mocha", "~> 1.1"
 
   spec.add_dependency "test-kitchen", ">= 1.4", "< 3"
+  spec.add_dependency "train", "~> 3.5"
+  spec.add_dependency "train-winrm", "~> 0.2"
 end

--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -23,6 +23,8 @@ require_relative "powershell"
 require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 require "fileutils" unless defined?(FileUtils)
 require "json" unless defined?(JSON)
+require "train" unless defined?(Train)
+require "train-winrm" unless defined?(TrainPlugins::WinRM)
 
 module Kitchen
 
@@ -34,8 +36,9 @@ module Kitchen
       kitchen_driver_api_version 2
       plugin_version Kitchen::Driver::HYPERV_VERSION
 
-      default_config :parent_vhd_folder
-      default_config :parent_vhd_name
+      required_config :parent_vhd_folder
+      required_config :parent_vhd_name
+
       default_config :memory_startup_bytes, 536_870_912
       default_config :dynamic_memory_min_bytes, 536_870_912
       default_config :dynamic_memory_max_bytes, 2_147_483_648
@@ -59,6 +62,13 @@ module Kitchen
       default_config :disk_type do |driver|
         File.extname(driver[:parent_vhd_name])
       end
+
+      default_config :hyperv_server, nil
+      default_config :hyperv_username, nil
+      default_config :hyperv_password, nil
+      default_config :hyperv_ssl, false
+      default_config :hyperv_insecure, true
+      default_config :remote_vm_path, 'C:\Users\Public\Documents\Hyper-V'
 
       include Kitchen::Driver::PowerShellScripts
 
@@ -94,8 +104,8 @@ module Kitchen
       private
 
       def validate_vm_settings
-        raise "Missing parent_vhd_folder" unless vhd_folder?
-        raise "Missing parent_vhd_name" unless vhd?
+        raise "Missing parent_vhd_folder" unless vhd_folder? || remote_hyperv
+        raise "Missing parent_vhd_name" unless vhd? || remote_hyperv
 
         if config[:dynamic_memory]
           startup_bytes = config[:memory_startup_bytes]
@@ -244,6 +254,8 @@ module Kitchen
       end
 
       def remove_differencing_disk
+        return unless differencing_disk_exists
+
         info("Removing the differencing disk for #{instance.name}.")
         FileUtils.rm(differencing_disk_path)
         info("Removed the differencing disk for #{instance.name}.")
@@ -269,12 +281,18 @@ module Kitchen
         @kitchen_vm_path ||= File.join(config[:kitchen_root], ".kitchen/#{instance.name}")
       end
 
+      def remote_kitchen_vm_path
+        config[:remote_vm_path]
+      end
+
       def boot_iso_path
         @boot_iso_path ||= config[:boot_iso_path]
       end
 
       def differencing_disk_path
-        @differencing_disk_path ||= File.join(kitchen_vm_path, "diff" + "#{config[:disk_type]}")
+        kitchen_vm_base = remote_hyperv ? remote_kitchen_vm_path : kitchen_vm_path
+
+        @differencing_disk_path ||= File.join(kitchen_vm_base, "diff" + "#{config[:disk_type]}")
       end
 
       def additional_disk_path(disk_name, disk_type)
@@ -291,6 +309,44 @@ module Kitchen
 
       def vhd?
         config[:parent_vhd_name] && File.exist?(parent_vhd_path)
+      end
+
+      def remote_hyperv
+        !!config[:hyperv_server]
+      end
+
+      def connection
+        return @connection if @connection
+
+        backend = remote_hyperv ? "winrm" : "local"
+
+        train = Train.create(backend, {
+                              host:        config[:hyperv_server],
+                              user:        config[:hyperv_username],
+                              password:    config[:hyperv_password],
+                              ssl:         config[:hyperv_ssl],
+                              self_signed: config[:hyperv_insecure],
+                            })
+        @connection = train.connection
+
+        # Copy support PS1
+        @connection.upload(local_script_path, remote_script_path)
+
+        @connection
+      end
+
+      def base_script_path
+        return remote_script_path if remote_hyperv
+
+        local_script_path
+      end
+
+      def local_script_path
+        File.join(File.dirname(__FILE__), "/../../../support/hyperv.ps1")
+      end
+
+      def remote_script_path
+        File.join(config[:kitchen_root], "kitchen-hyperv", "hyperv.ps1")
       end
     end
   end

--- a/spec/kitchen/driver/hyperv_spec.rb
+++ b/spec/kitchen/driver/hyperv_spec.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-#
 # Author:: Fletcher (<fnichol@nichol.ca>)
 #
 # Copyright (C) 2020, Fletcher Nichol
@@ -31,7 +29,7 @@ describe Kitchen::Driver::Hyperv do
 
   let(:logged_output) { StringIO.new }
   let(:logger)        { Logger.new(logged_output) }
-  let(:config)        { { kitchen_root: "c:/test_root" } }
+  let(:config)        { { kitchen_root: "c:/test_root", parent_vhd_folder: "C:/Virtual Machines", parent_vhd_name: "dummy.vhdx" } }
   let(:platform)      { Kitchen::Platform.new(name: "fooos-99") }
   let(:suite)         { Kitchen::Suite.new(name: "suitey") }
   let(:verifier)      { Kitchen::Verifier::Dummy.new }
@@ -56,6 +54,6 @@ describe Kitchen::Driver::Hyperv do
   # before { stub_const("ENV", env) }
 
   it "driver api_version is 2" do
-    driver.diagnose_plugin[:api_version].must_equal(2)
+    _(driver.diagnose_plugin[:api_version]).must_equal(2)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
-# -*- encoding: utf-8 -*-
-#
+
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #
 # Copyright (C) 2012, Fletcher Nichol
@@ -39,5 +38,5 @@ end
 require "minitest"
 require "minitest/stub_const"
 require "minitest/autorun"
-require "mocha/setup"
+require "mocha/minitest"
 require "tempfile" unless defined?(Tempfile)

--- a/support/hyperv.ps1
+++ b/support/hyperv.ps1
@@ -18,8 +18,8 @@ function New-DifferencingDisk {
         [parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string[]]$Path,
-        [parameter(Mandatory)]        
-        [ValidateNotNullOrEmpty()] 
+        [parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
         [string]$ParentPath
     )
     if (-not (Test-Path $Path)) {
@@ -73,9 +73,9 @@ function New-KitchenVM {
         $EnableGuestServices,
         $AdditionalDisks
     )
-    $null = $psboundparameters.remove('DisableSecureBoot')    
+    $null = $psboundparameters.remove('DisableSecureBoot')
     $null = $psboundparameters.remove('ProcessorCount')
-    $null = $psboundparameters.remove('StaticMacAddress') 
+    $null = $psboundparameters.remove('StaticMacAddress')
     $null = $psboundparameters.remove('UseDynamicMemory')
     $null = $psboundparameters.remove('DynamicMemoryMinBytes')
     $null = $psboundparameters.remove('DynamicMemoryMaxBytes')
@@ -99,7 +99,7 @@ function New-KitchenVM {
     if (-not [string]::IsNullOrEmpty($boot_iso_path)) {
         Mount-VMISO -Id $vm.Id -Path $boot_iso_path
     }
-    if ($StaticMacAddress -ne $null) {
+    if (-not [string]::IsNullOrEmpty($StaticMacAddress)) {
         Set-VMNetworkAdapter -VMName $vm.VMName -StaticMacAddress $StaticMacAddress
     }
     if ($EnableGuestServices -and (Get-command Enable-VMIntegrationService -ErrorAction SilentlyContinue)) {


### PR DESCRIPTION
# Description

Allow use of remote Hyper-V servers for Test Kitchen machines.

Based on Train (3.5+) abilities to upload files and the Train WinRM backend for remote execution, still allowing all existing PS commands to be used.

## Issues Resolved

Feature Request #10 

Also adjusted style to recent recommendations and fixed tests.

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality has been documented in the README if applicable.
