### PR TITLE
error handling of undefined method [] for nil class error when creat…

### DIFF
--- a/lib/kitchen/driver/hyperv.rb
+++ b/lib/kitchen/driver/hyperv.rb
@@ -160,6 +160,7 @@ module Kitchen
 
         info("Creating virtual machine for #{instance.name}.")
         new_vm_object = run_ps new_vm_ps
+        raise "Unable to create virtual machine for #{instance.name}." if new_vm_object.nil?
         @state[:id] = new_vm_object["Id"]
         info("Created virtual machine for #{instance.name}.")
       end


### PR DESCRIPTION
…ion of wm faile

# Description
When kitchen fails to create a new wm in some cases the error message posted in the console is 
`undefined method `[]' for nil class`

## Issues Resolved
Missing error message 

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
