### PR TITLE
feat: Add publish to RubyGems into the workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,8 @@ updates:
   - package-ecosystem: bundler
     directory: "/"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+    open-pull-requests-limit: 5
     ignore:
       - dependency-name: github_changelog_generator
         versions:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,7 +1,7 @@
 ---
-name: 'Test'
+name: "Lint Unit"
 
-'on':
+"on":
   pull_request:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,28 @@
 ---
 name: Publish
 
-'on':
+"on":
   release:
     types: [published]
 
 jobs:
-  build:
+  publish-to-github:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build and publish gem
-        uses: jstastny/publish-gem-to-github@master
+
+      - name: Build and publish to GitHub Package
+        uses: actionshub/publish-gem-to-github@v1.0.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           owner: ${{ secrets.OWNER }}
+
+  publish-to-rubygems:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build and publish to RubyGems
+        uses: actionshub/publish-gem-to-rubygems@v1.0.0
+        with:
+          api_key: ${{ secrets.RUBY_GEMS_API_KEY }}


### PR DESCRIPTION
# Description

feat: Add publish to RubyGems into the workflow
Additionally, switch the publishing workflow for GitHub Packages to ActionsHub

## Issues Resolved

None

## Type of Change

Our release process assumes you are using Conventional Commit messages.

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
